### PR TITLE
fix logic to match test description and the desired behavior

### DIFF
--- a/controllers/bookmarks_controller_spec.rb
+++ b/controllers/bookmarks_controller_spec.rb
@@ -55,7 +55,7 @@ if defined?(BookmarksController)
 
         it "re-renders the 'new' template or 'lists/show'" do
           post :create, params: invalid_attributes
-          expect(response).to render_template('new').or redirect_to(@list)
+          expect(response).to render_template('new').or render_template('lists/show')
         end
       end
     end


### PR DESCRIPTION
When trying to create a bookmark with invalid params, the app should re-render the 'new' template or the 'lists/show'.

The test logic was checking if the client was being **redirected to** the list view, which is not the intended behavior when we try to create a bookmark with invalid params.

Instead of redirecting, we want to re-render the 'lists/show', **without a redirection**, so we can fix the bad input.