### PR TITLE
Improve wording on dependent destroy for bookmarks on lists

### DIFF
--- a/models/list_spec.rb
+++ b/models/list_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "List", type: :model do
     expect(list.movies.count).to eq(1)
   end
 
-  it "should destroy child saved movies when destroying self" do
+  it "should destroy child bookmarks when destroying self (in other words, should remove movies from the list when it is deleted)" do
     list = List.create!(valid_attributes)
     list.bookmarks.create(list: list, movie: titanic, comment: "Great movie!")
     expect { list.destroy }.to change { Bookmark.count }.from(1).to(0)


### PR DESCRIPTION
I realized the wording on this was super confusing when teaching it the other day. Hopefully this change should be fairly self-explanatory/OK to merge