### PR TITLE
Fix versioning issue with fixture_path= method

### DIFF
--- a/rails_helper.rb
+++ b/rails_helper.rb
@@ -26,7 +26,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_path = "#{::Rails.root}/spec/fixtures" if config.respond_to?(:fixture_path=)
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Reported by a teacher. I guess in theory we might be able to get away with removing the line, but this is a quick fix that prevents any changes in behavior.

https://lewagon-alumni.slack.com/archives/G02NFDT0J/p1772111256271779